### PR TITLE
Fix versioning issue preventing releases

### DIFF
--- a/DecSm.Extensions.Hosting.Tests/DecSm.Extensions.Hosting.Tests.csproj
+++ b/DecSm.Extensions.Hosting.Tests/DecSm.Extensions.Hosting.Tests.csproj
@@ -11,7 +11,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="FakeItEasy" Version="8.3.0"/>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0"/>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0"/>
     <PackageReference Include="NUnit" Version="4.3.2"/>
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0"/>

--- a/_atom/_atom.csproj
+++ b/_atom/_atom.csproj
@@ -21,10 +21,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="DecSm.Atom" Version="1.0.0-rc.367"/>
-    <PackageReference Include="DecSm.Atom.Module.Dotnet" Version="1.0.0-rc.367"/>
-    <PackageReference Include="DecSm.Atom.Module.GithubWorkflows" Version="1.0.0-rc.367"/>
-    <PackageReference Include="DecSm.Atom.Module.GitVersion" Version="1.0.0-rc.367"/>
+    <PackageReference Include="DecSm.Atom" Version="1.0.0-rc.369" />
+    <PackageReference Include="DecSm.Atom.Module.Dotnet" Version="1.0.0-rc.369" />
+    <PackageReference Include="DecSm.Atom.Module.GithubWorkflows" Version="1.0.0-rc.369" />
+    <PackageReference Include="DecSm.Atom.Module.GitVersion" Version="1.0.0-rc.369" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This pull request includes updates to package references in two project files to ensure compatibility with the latest versions.

Dependency updates:

* [`DecSm.Extensions.Hosting.Tests/DecSm.Extensions.Hosting.Tests.csproj`](diffhunk://#diff-7803e8f13d9c83e2856ed147fbabce1b63df4f87a5587010db3349ffd56b6b28L14-R14): Updated `Microsoft.Extensions.DependencyInjection` package from version 8.0.0 to 9.0.1.
* [`_atom/_atom.csproj`](diffhunk://#diff-39274b2846e2cdce854a552450b64470d07d75460980b9fb6630c7c5ffdca297L24-R27): Updated `DecSm.Atom` and related modules from version 1.0.0-rc.367 to 1.0.0-rc.369.