### PR TITLE
Add release trigger and upgrade package versions

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -2,6 +2,9 @@ name: Build
 
 on:
   workflow_dispatch:
+  release:
+    types: [ released ]
+  
   push:
     branches:
       - 'main'

--- a/_atom/Build.cs
+++ b/_atom/Build.cs
@@ -1,6 +1,4 @@
-﻿using Atom.Targets;
-
-namespace Atom;
+﻿namespace Atom;
 
 [BuildDefinition]
 [GenerateEntryPoint]
@@ -29,7 +27,7 @@ internal sealed partial class Build : DefaultBuildDefinition,
         },
         new("Build")
         {
-            Triggers = [GitPushTrigger.ToMain, ManualTrigger.Empty],
+            Triggers = [GitPushTrigger.ToMain, GithubReleaseTrigger.OnReleased, ManualTrigger.Empty],
             StepDefinitions =
             [
                 Commands.SetupBuildInfo,

--- a/_atom/_atom.csproj
+++ b/_atom/_atom.csproj
@@ -21,10 +21,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="DecSm.Atom" Version="1.0.0-rc.369" />
-    <PackageReference Include="DecSm.Atom.Module.Dotnet" Version="1.0.0-rc.369" />
-    <PackageReference Include="DecSm.Atom.Module.GithubWorkflows" Version="1.0.0-rc.369" />
-    <PackageReference Include="DecSm.Atom.Module.GitVersion" Version="1.0.0-rc.369" />
+    <PackageReference Include="DecSm.Atom" Version="1.0.0-rc.371" />
+    <PackageReference Include="DecSm.Atom.Module.Dotnet" Version="1.0.0-rc.371" />
+    <PackageReference Include="DecSm.Atom.Module.GithubWorkflows" Version="1.0.0-rc.371" />
+    <PackageReference Include="DecSm.Atom.Module.GitVersion" Version="1.0.0-rc.371" />
   </ItemGroup>
 
 </Project>

--- a/_atom/_usings.cs
+++ b/_atom/_usings.cs
@@ -1,7 +1,9 @@
+global using Atom.Targets;
 global using DecSm.Atom;
 global using DecSm.Atom.Build.Definition;
 global using DecSm.Atom.Module.Dotnet;
 global using DecSm.Atom.Module.GithubWorkflows;
+global using DecSm.Atom.Module.GithubWorkflows.Generation.Options;
 global using DecSm.Atom.Module.GitVersion;
 global using DecSm.Atom.Params;
 global using DecSm.Atom.Workflows.Definition;


### PR DESCRIPTION
Added a GitHub release trigger to the build workflow and updated package references to version 1.0.0-rc.371. Also reorganized `using` directives to include required namespaces and removed unused ones. This enhances release automation and keeps dependencies up-to-date.