### PR TITLE
Add PushToRelease target and workflow integration

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -99,3 +99,28 @@ jobs:
         run: dotnet run --project _atom/_atom.csproj PushToNuget --skip --headless
         env:
           nuget-push-api-key: ${{ secrets.NUGET_PUSH_API_KEY }}
+  
+  PushToRelease:
+    needs: [ PackHostingExtensions ]
+    runs-on: ubuntu-latest
+    steps:
+      
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
+      
+      - name: Download DecSm.Extensions.Hosting
+        uses: actions/download-artifact@v4
+        with:
+          name: DecSm.Extensions.Hosting
+          path: "${{ github.workspace }}/.github/artifacts/DecSm.Extensions.Hosting"
+      
+      - name: PushToRelease
+        id: PushToRelease
+        run: dotnet run --project _atom/_atom.csproj PushToRelease --skip --headless
+        env:
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/_atom/Build.cs
+++ b/_atom/Build.cs
@@ -7,10 +7,13 @@ internal sealed partial class Build : DefaultBuildDefinition,
     IGithubWorkflows,
     IPackHostingExtensions,
     ITestHostingExtensions,
-    IPushToNuget
+    IPushToNuget,
+    IPushToRelease
 {
-    public override IReadOnlyList<IWorkflowOption>
-        DefaultWorkflowOptions => [UseGitVersionForBuildId.Enabled, new SetupDotnetStep("9.0.x")];
+    public override IReadOnlyList<IWorkflowOption> DefaultWorkflowOptions =>
+    [
+        UseGitVersionForBuildId.Enabled, new SetupDotnetStep("9.0.x"),
+    ];
 
     public override IReadOnlyList<WorkflowDefinition> Workflows =>
     [
@@ -34,6 +37,7 @@ internal sealed partial class Build : DefaultBuildDefinition,
                 Commands.PackHostingExtensions,
                 Commands.TestHostingExtensions,
                 Commands.PushToNuget.WithAddedOptions(WorkflowSecretInjection.Create(Params.NugetApiKey)),
+                Commands.PushToRelease.WithGithubTokenInjection(),
             ],
             WorkflowTypes = [Github.WorkflowType],
         },

--- a/_atom/Targets/IPushToRelease.cs
+++ b/_atom/Targets/IPushToRelease.cs
@@ -1,0 +1,22 @@
+﻿namespace Atom.Targets;
+
+[TargetDefinition]
+internal partial interface IPushToRelease : IGithubReleaseHelper
+{
+    Target PushToRelease =>
+        d => d
+            .WithDescription("Pushes the package to the release feed.")
+            .RequiresParam(Params.GithubToken)
+            .ConsumesArtifact(Commands.PackHostingExtensions, IPackHostingExtensions.HostingExtensionsProjectName)
+            .Executes(async () =>
+            {
+                if (Version.IsPreRelease)
+                {
+                    Logger.LogInformation("Skipping release push for pre-release version");
+
+                    return;
+                }
+
+                await UploadArtifactToRelease(IPackHostingExtensions.HostingExtensionsProjectName);
+            });
+}

--- a/_atom/_atom.csproj
+++ b/_atom/_atom.csproj
@@ -21,10 +21,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="DecSm.Atom" Version="1.0.0-rc.371" />
-    <PackageReference Include="DecSm.Atom.Module.Dotnet" Version="1.0.0-rc.371" />
-    <PackageReference Include="DecSm.Atom.Module.GithubWorkflows" Version="1.0.0-rc.371" />
-    <PackageReference Include="DecSm.Atom.Module.GitVersion" Version="1.0.0-rc.371" />
+    <PackageReference Include="DecSm.Atom" Version="1.0.0-rc.378" />
+    <PackageReference Include="DecSm.Atom.Module.Dotnet" Version="1.0.0-rc.378" />
+    <PackageReference Include="DecSm.Atom.Module.GithubWorkflows" Version="1.0.0-rc.378" />
+    <PackageReference Include="DecSm.Atom.Module.GitVersion" Version="1.0.0-rc.378" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Introduce the `IPushToRelease` target to enable pushing artifacts to the release feed, skipping for pre-releases. Updated GitHub Actions workflow and build integration to support this new release step. Upgraded dependencies to version `1.0.0-rc.378` for compatibility.