### PR TITLE
fix(build): remove unnecessary parameter requirements for GitHub release

### DIFF
--- a/_atom/ITargets.cs
+++ b/_atom/ITargets.cs
@@ -65,7 +65,6 @@ internal interface ITargets : IDotnetPackHelper, IDotnetTestHelper, INugetHelper
             .DescribedAs("Pushes artifacts to a GitHub release")
             .RequiresParam(nameof(GithubToken))
             .ConsumesVariable(nameof(SetupBuildInfo), nameof(BuildVersion))
-            .RequiresParam(nameof(NugetFeed), nameof(NugetApiKey))
             .ConsumesArtifacts(nameof(Pack), ProjectsToPack)
             .ConsumesArtifacts(nameof(Test),
                 ProjectsToTest,


### PR DESCRIPTION
Removed redundant `NugetFeed` and `NugetApiKey` parameter requirements from the `PushToRelease` target in `ITargets.cs`. This simplifies configuration for GitHub release workflows.